### PR TITLE
Remove old circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/18F/analytics-restarter.svg?style=svg)](https://circleci.com/gh/18F/analytics-restarter)
+
 # Analytics Restarter
 
 This app triggers nightly builds for the apps that makeup the [analytics.usa.gov](https://analytics.usa.gov) system. These apps include:

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
-deployment:
-  master:
-    branch: master
-    commands:
-      - bin/deploy-ci.sh


### PR DESCRIPTION
Removes the old CircleCI 1.0 config. Adds the CI badge.