### PR TITLE
Upgrade to cflinuxfs3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,29 +3,29 @@ GEM
   specs:
     circleci (2.0.2)
     diff-lcs (1.3)
-    mustermann (1.0.2)
-    rack (2.0.4)
-    rack-protection (2.0.1)
+    mustermann (1.0.3)
+    rack (2.0.7)
+    rack-protection (2.0.5)
       rack
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    sinatra (2.0.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
     timecop (0.9.1)
 
 PLATFORMS
@@ -38,7 +38,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.4.5p335
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ instances: 1
 memory: 128M
 services:
 - circleci
+stack: cflinuxfs3


### PR DESCRIPTION
We need to make this update because cloud.gov is ending support for cflinuxfs2