### PR TITLE
Increment from cflinuxfs3 to 4

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,4 @@ instances: 1
 memory: 128M
 services:
 - circleci
-stack: cflinuxfs3
+stack: cflinuxfs4


### PR DESCRIPTION
This PR tracks work on remediating the Clloud.gov Ubuntu stack dependency moving from cflinuxfs3 to 4.